### PR TITLE
mysql: skip performance_schema

### DIFF
--- a/templates/dump_databases.epp
+++ b/templates/dump_databases.epp
@@ -31,7 +31,7 @@ alias pigz="pigz --processes $_pigz_processes"
 # mysql stuff
 _mysqlopts='--add-drop-database --add-drop-table --create-options --disable-keys --add-locks --lock-tables --extended-insert --quick --set-charset'
 # skip the following databases
-_skipdbs="information_schema"
+_skipdbs="information_schema performance_schema"
 # misc stuff
 _hostname="$(hostname)"
 _date=$(date +"%Y-%m-%d")


### PR DESCRIPTION
newer MySQL versions have a performance_schema database. It provides
lowlevel performance metrics. Dumping the database will fail.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
