### PR TITLE
systemd: Set WorkingDirectory=~

### DIFF
--- a/templates/dump_databases.service.epp
+++ b/templates/dump_databases.service.epp
@@ -9,6 +9,7 @@ After=network.target
 
 [Service]
 Type=oneshot
+WorkingDirectory=~
 ExecStart=/usr/local/bin/dump_databases
 <% if $backuphistory { -%>
 ExecStartPost=/usr/bin/find <%= $destination %> -mtime +<%= $backuphistory %> -delete


### PR DESCRIPTION
people might have an additional .my.cnf in ~. Without WorkingDirectory,
mysql will check for /.my.cnf, not /root/.my.cnf

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
