### PR TITLE
Fail script on error

### DIFF
--- a/templates/dump_databases.epp
+++ b/templates/dump_databases.epp
@@ -17,6 +17,8 @@
 # 2019-05-09  - use correct fileending for LDAP dumps
 ##
 
+set -e
+
 # pigz
 _pigz_processes="<%= $pigz_cpu_cores %>"
 if [[ -n $_pigz_processes ]] ; then


### PR DESCRIPTION
Otherwise, the systemd service will always show a success, f.e. when no dumps are created because pigz isn't installed.